### PR TITLE
adds support NULL element in Int32Array{}

### DIFF
--- a/int32_array.go
+++ b/int32_array.go
@@ -53,7 +53,11 @@ func (a *Int32Array) Scan(value interface{}) error {
 		}
 		i, err := strconv.Atoi(s)
 		if err != nil {
-			return err
+			if s == "NULL" {
+				i = 0
+			} else {
+				return err
+			}
 		}
 		res = append(res, int32(i))
 	}


### PR DESCRIPTION
Hi!

It's possible to have NULL element in intarray. See row with ID = 1

![image](https://cloud.githubusercontent.com/assets/2199318/13581002/1397bd62-e4a5-11e5-9558-484fdc614eab.png)

```
create table device_states (
   id                   INT4                 not null,
   is_mounted           BOOL                 not null,
   name                 jsonb                null,
   transition_ids       int4[]               null,
   constraint PK_DEVICE_STATES primary key (id)
);

```
