### PR TITLE
Add simple `sql.Null...` type conversions

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -1,0 +1,41 @@
+package pq_types
+
+import (
+	"database/sql"
+	"time"
+)
+
+// NullString covers trivial case of string to sql.NullString conversion assuming empty string to be NULL
+func NullString(src string) sql.NullString {
+	return sql.NullString{
+		String: src,
+		Valid:  src != "",
+	}
+}
+
+// NullInt32 covers trivial case of int32 to sql.NullInt32 conversion assuming 0 to be NULL
+func NullInt32(src int32) sql.NullInt32 {
+	return sql.NullInt32{
+		Int32: src,
+		Valid: src != 0,
+	}
+}
+
+// NullInt64 covers trivial case of int64 to sql.NullInt64 conversion assuming 0 to be NULL
+func NullInt64(src int64) sql.NullInt64 {
+	return sql.NullInt64{
+		Int64: src,
+		Valid: src != 0,
+	}
+}
+
+// NullTimestampP converts *time.Time to a sql.NullTime
+func NullTimestampP(src *time.Time) sql.NullTime {
+	if src == nil {
+		return sql.NullTime{Valid: false}
+	}
+	return sql.NullTime{
+		Time:  *src,
+		Valid: true,
+	}
+}

--- a/conversions_test.go
+++ b/conversions_test.go
@@ -1,0 +1,90 @@
+package pq_types
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+func insertQuery(col string) string {
+	return fmt.Sprintf("INSERT INTO pq_types (%s) VALUES($1)", col)
+}
+
+func selectQuery(col string) string {
+	return fmt.Sprintf("SELECT %s FROM pq_types LIMIT 1;", col)
+}
+
+// For each type there need to be a pair of tests: with empty -> nil value and with non-empty value -> value.
+
+func (s *TypesSuite) TestConversionNullString(c *check.C) {
+	cases := []sql.NullString{
+		{String: ""},
+		{String: "truly random string", Valid: true},
+	}
+	for _, expected := range cases {
+		val := NullString(expected.String)
+		_, err := s.db.Exec(insertQuery("null_str"), val)
+		c.Assert(err, check.IsNil)
+
+		var actual sql.NullString
+		err = s.db.QueryRow(selectQuery("null_str")).Scan(actual)
+		c.Check(err, check.IsNil)
+		c.Check(actual, check.DeepEquals, expected)
+	}
+}
+
+func (s *TypesSuite) TestConversionNullInt32(c *check.C) {
+	cases := []sql.NullInt32{
+		{Int32: 0},
+		{Int32: 0xabc, Valid: true},
+	}
+	for _, expected := range cases {
+		val := NullInt32(expected.Int32)
+		_, err := s.db.Exec(insertQuery("null_int32"), val)
+		c.Assert(err, check.IsNil)
+
+		var actual sql.NullInt32
+		err = s.db.QueryRow(selectQuery("null_int32")).Scan(actual)
+		c.Check(err, check.IsNil)
+		c.Check(actual, check.DeepEquals, expected)
+	}
+}
+
+func (s *TypesSuite) TestConversionNullInt64(c *check.C) {
+	cases := []sql.NullInt64{
+		{Int64: 0},
+		{Int64: 0xabcdef, Valid: true},
+	}
+	for _, expected := range cases {
+		val := NullInt64(expected.Int64)
+		_, err := s.db.Exec(insertQuery("null_int64"), val)
+		c.Assert(err, check.IsNil)
+
+		var actual sql.NullInt64
+		err = s.db.QueryRow(selectQuery("null_int64")).Scan(actual)
+		c.Check(err, check.IsNil)
+		c.Check(actual, check.DeepEquals, expected)
+	}
+}
+
+func (s *TypesSuite) TestConversionNullTimestamp(c *check.C) {
+	// here we use another approach, as input is a pointer
+	now := time.Now()
+	cases := []*time.Time{nil, &now}
+
+	for _, expected := range cases {
+		s.SetUpTest(c)
+
+		val := NullTimestampP(expected)
+
+		_, err := s.db.Exec(insertQuery("null_timestamp"), val)
+		c.Assert(err, check.IsNil)
+
+		var actual *time.Time
+		err = s.db.QueryRow(selectQuery("null_timestamp")).Scan(&actual)
+		c.Check(err, check.IsNil)
+		c.Check(actual, check.Equals, expected)
+	}
+}

--- a/sqltypes_test.go
+++ b/sqltypes_test.go
@@ -89,7 +89,11 @@ func (s *TypesSuite) SetUpSuite(c *C) {
 		string_array varchar[],
 		int32_array int[],
 		int64_array bigint[],
-		jsontext_varchar varchar
+		jsontext_varchar varchar,
+		null_str varchar,
+		null_int32 int4,
+		null_int64 int8,
+		null_timestamp timestamptz
 	)`)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Add conversions for `string`, `int32`, `int64`, `*time.Time` to the corresponding `sql.Null...` types